### PR TITLE
Remove semi-colon on cover page

### DIFF
--- a/tudelft-report.cls
+++ b/tudelft-report.cls
@@ -454,7 +454,7 @@
                      
                      {\titlefont\color{\@covertextcolor}\fontsize{18}{18}\selectfont\@cover@text}
                    \fi
-             \end{minipage};
+             \end{minipage}
             };
         \else
           \coordinate (tcorner) at ($(top left)+(\@cover@x,-\@cover@y)$);


### PR DESCRIPTION
You can see the `;` in the top right corner of the image below

![image](https://cloud.githubusercontent.com/assets/5948271/14881444/43083254-0d34-11e6-92ea-8d989f9388cb.png)
