### PR TITLE
Use polyglossia instead of babel when compiling with Xe(La)TeX

### DIFF
--- a/tudelft-report.cls
+++ b/tudelft-report.cls
@@ -23,28 +23,38 @@
 
 \LoadClass[10pt]{book}
 
+\RequirePackage{ifxetex}
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}
+
 %% English is the default language, but this can be changed to Dutch by
 %% specifying the 'dutch' option to the document class.
-\if@dutch
-    \RequirePackage[dutch]{babel}
+%% Even for English reports, some sections might be in Dutch, for example on
+%% the title page, so also load dutch as alternative language in this case.
+\ifxetex
+    \RequirePackage{polyglossia}
+    \if@dutch
+        \setdefaultlanguage{dutch}
+    \else
+        \setdefaultlanguage{english}
+        \setotherlanguage{dutch}
+    \fi
 \else
-    %% Even for English reports, some sections might be in Dutch, for example on
-    %% the title page.
-    \RequirePackage[dutch,english]{babel}
+    \if@dutch
+        \RequirePackage[dutch]{babel}
+    \else
+        \RequirePackage[dutch,english]{babel}
+    \fi
 \fi
 \RequirePackage[nooneline,footnotesize]{caption}
 \RequirePackage{fancyhdr}
 \RequirePackage[flushmargin,hang]{footmisc}
 \RequirePackage{ifpdf}
-\RequirePackage{ifxetex}
 \ifxetex
-    \RequirePackage[xetex]{geometry}
-    \RequirePackage[xetex]{graphicx}
-    \RequirePackage[xetex]{hyperref}
+    \RequirePackage{geometry}
+    \RequirePackage{graphicx}
+    \RequirePackage{hyperref}
     \RequirePackage{fontspec}
-    \RequirePackage{xltxtra}
     \defaultfontfeatures{Ligatures=TeX}
 \else
     \ifpdf


### PR DESCRIPTION
XeTeX and XeLaTeX use polyglossia instead of babel, so use that instead when compiling with either of those two, and otherwise use babel like normal. See: http://tex.stackexchange.com/a/3000

This seems to change some other behaviour as well: the font of the main body is now BookmanOldStyle instead of Arial. By looking at the code, this seems to be the intended behaviour (see the line with the "\setmainfont" command).

I removed the driver options ([xetex]) as per this answer on TeX.stackexchange: http://tex.stackexchange.com/a/2985. I also removed the `xlxtra` package as per http://tex.stackexchange.com/a/3000.

In the case of the graphicx package, the xetex option was removed because it produced an error for me due to conflicting package options: [xetex] vs [](i.e. no options). This error only arose after switching to polyglossia. This leads me to believe that indeed it is not used in practice (since another package decided to load it without the xetex driver option).
